### PR TITLE
Using non-root user in container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM python:bullseye
 
+RUN adduser --system --group --no-create-home printy
+
 COPY . .
 
+USER printy
 CMD [ "python3", "./main.py" ]


### PR DESCRIPTION
This PR removes root from the Dockerfile. Basic security, nothing big. 